### PR TITLE
[fix] Remove unusable markdown url

### DIFF
--- a/pages/channels/welcome.md
+++ b/pages/channels/welcome.md
@@ -36,5 +36,6 @@ The channel contains the following posts:
 > 👁️ Check out this server's repo: https://github.com/TodePond/Lilypad <br>
 > (work-in-progress, currently in alpha)
 >
-> It's the place to discuss the running of the Lilypad, and to suggest changes. For example, this post (that you're reading right now) was added via a [pull request](https://github.com/TodePond/Lilypad/pull/35)! It's still missing a lot of information, but it's a start! ⭐
-
+> It's the place to discuss the running of the Lilypad, and to suggest changes. For example, this post (that you're reading right now) was added via a pull request: https://github.com/TodePond/Lilypad/pull/35
+>
+> It's still missing a lot of information, but it's a start! ⭐


### PR DESCRIPTION
You can't use markdown links in discord, so I had to change the #welcome post a little bit