### PR TITLE
Rename and reorder #accidents

### DIFF
--- a/pages/channels.md
+++ b/pages/channels.md
@@ -16,8 +16,8 @@ These are the different channels of the Lilypad server.
 >    
 > **The Pond**<br>
 #journal<br>
-#accidents<br>
 #links<br>
+#oops<br>
 #ribbit
 > 
 > **The Roost**<br>
@@ -64,8 +64,8 @@ Some channels are uncategorised, so are listed at the top level.
 |Channel|Type|Description|Restrictions|
 |--|--|--|--|
 |#journal|Text|show us something you're making!||
-|#accidents|Text|show us something you made... by accident!||
 |#links|Text|show us something you found!||
+|#accidents|Text|show us something you made... by accident!||
 |#ribbit|Text|ribbit ribbit||
 
 ### The Roost

--- a/pages/channels/welcome.md
+++ b/pages/channels/welcome.md
@@ -15,9 +15,9 @@ The channel contains the following posts:
 > ⭐ coding + cellular automata<br>
 > ⭐ creativity + nature<br>
 > 
-> ⁠journal - show us something you're making!<br>
-> ⁠accidents - show us something you made by accident!<br>
-> ⁠links - show us something you found!<br>
+> ⁠#journal - show us something you're making!<br>
+> ⁠#links - show us something you found!<br>
+> #oops - show us something you made by mistake!<br>
 > 
 > New people arrive in ⁠lobby!<br>
 > Let's be kind+respectful to everyone! :)<br>


### PR DESCRIPTION
This PR renames 'accidents' to 'oops' and reorders them. It also updates the 'welcome' page to reflect this.

Rationale:

1. 'oops' is more fun.
2. 'oops' welcomes a wider range of 'things going wrong'.
3. This positions 'journal' and 'links' as being the too most important channels, reflecting the purposes of the server.

Closes #15 